### PR TITLE
Fix default value for TMP_GEN_DIR

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -82,7 +82,7 @@ CERT_VERIFY_URL = ''
 if os.path.isfile(ENV_ROOT / "env.json"):
     with open(ENV_ROOT / "env.json") as env_file:
         ENV_TOKENS = json.load(env_file)
-    TMP_GEN_DIR = ENV_TOKENS.get('TMP_GEN_DIR', '/var/tmp')
+    TMP_GEN_DIR = ENV_TOKENS.get('TMP_GEN_DIR', '/tmp/certificates/')
     QUEUE_NAME = ENV_TOKENS.get('QUEUE_NAME', 'test-pull')
     QUEUE_URL = ENV_TOKENS.get('QUEUE_URL', 'https://stage-xqueue.edx.org')
     CERT_GPG_DIR = ENV_TOKENS.get('CERT_GPG_DIR', CERT_GPG_DIR)


### PR DESCRIPTION
The default value was set to /var/tmp. This is bad, because it's not a directory prefix, it's a filename prefix. So the cert agent was trying to create temp working directories with names like /var/tmpAEOUCaoeu. And since most users don't have write perms to /var, that was failing.

Then we added the trailing /. Now it was creating /var/tmp/aeostdhaeou, which was better, except it assumes that the directory in which you're doing your work belongs exclusively to the user running the certificate agent. Consequently, when you do test runs using create_pdf, it would try to helpfully clean up after itself by doing rm -rf on /var/tmp. Which would be a bad idea even if you were running certs as a user who was allowed to do that.

In prod, we have this value configured to be `/tmp/certs-` which seems to work pretty well, so I think it would make sense to just make the default behavior that.
