### PR TITLE
Require pep8 now that we have a test dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ boto==2.27.0
 gnupg==1.4.0
 nose==1.2.1
 path.py==2.4.1
+pep8==1.5.7
 pyPdf2==1.23
 python-bidi==0.3.4
 PyYAML==3.11


### PR DESCRIPTION
- Since ccbdd82f3b420a535fb78f78a3695d584f784296, travis builds require
  pep8 to pass for the build to pass at all. This places the onus on the
  developer not to increase pep8 violations.
- Consequently, there is a practical dependency on having pep8 to do
  work on this codebase, even if there is no strict technical
  requirement for it.
- Install pep8 by default so developers can have more fun.

@sarina and @stvstnfrd 

I think the only point of contention is whether we should have developer requirements mixed in with the strict source requirements. I think that:
1. having multiple requirements files is a drag
2. pep8 is a pretty special thing that most developers immediately recognize
3. having pep8 installed (even in a dedicated docker container) won't hurt anything
