### PR TITLE
Improve create_pdfs summary report

### DIFF
--- a/create_pdfs.py
+++ b/create_pdfs.py
@@ -124,7 +124,7 @@ def main():
             (download_uuid, verify_uuid,
                 download_url) = cert.create_and_upload(name, upload=upload_files, copy_to_webroot=False,
                                                        cleanup=False, designation=title, grade=grade)
-            certificate_data.append((name, download_url))
+            certificate_data.append((name, course, long_org, long_course, download_url))
             gen_dir = os.path.join(cert.dir_prefix, S3_CERT_PATH, download_uuid)
             copy_dest = '{copy_dir}/{course}-{name}.pdf'.format(
                 copy_dir=copy_dir,
@@ -146,9 +146,8 @@ def main():
     if args.report_file:
         try:
             with open(args.report_file, 'wb') as file_report:
-                csv_writer = csv.writer(file_report, quoting=csv.QUOTE_MINIMAL)
-                for row in certificate_data:
-                    csv_writer.writerow(row)
+                csv_writer = csv.writer(file_report, quoting=csv.QUOTE_ALL)
+                csv_writer.writerows(certificate_data)
             should_write_report_to_stdout = False
         except IOError as error:
             LOG.error("Unable to open report file: %s", error)


### PR DESCRIPTION
- Add course id, long org and long course to the summary report, making it more useful
- Change csv_writer to use writerows() instead of writerow(), which is a little bit faster
- Changes from QUOTE_MINIMAL to QUOTE_ALL, so we can make safer assumptions in the future

To really see the value in this, make a branch with #30 and #31 applied, and this, and then run create_pdfs using a cert-data.yml file that has several dozen courses in it and using the -r flag. Then compare that output to running the same set of courses without this branch but with the -r flag.

@stvstnfrd I expect this will be uncontroversial.
