### PR TITLE
Make tmp dir if it does not exist.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 # Travis CI configuration file for running tests
 language: python
+sudo: false
 python:
   - "2.7"
-before_install:
-  - pip install pep8
-  - pep8 --verbose
 install:
   - pip install --allow-all-external -r requirements.txt
-  - pip install coverage
+  - pip install -r test_requirements.txt
 script:
+  - pep8 --verbose
   - |
     curl https://raw.githubusercontent.com/edx/configuration/master/playbooks/roles/certs/files/example-private-key.txt -o /var/tmp/key.txt
     curl https://raw.githubusercontent.com/edx/configuration/master/playbooks/roles/certs/files/example-key-ownertrust.txt -o /var/tmp/trust.txt
@@ -16,5 +15,4 @@ script:
     /usr/bin/gpg --import-ownertrust /var/tmp/trust.txt
     nosetests --with-coverage
 after_success:
-  - pip install coveralls
   - coveralls

--- a/gen_cert.py
+++ b/gen_cert.py
@@ -209,6 +209,7 @@ class CertificateGen(object):
                            template_pdf parameter
         """
         if dir_prefix is None:
+            self._ensure_dir(TMP_GEN_DIR)
             dir_prefix = tempfile.mkdtemp(prefix=TMP_GEN_DIR)
         self._ensure_dir(dir_prefix)
         self.dir_prefix = dir_prefix

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,4 @@
+mock==1.3.0
+coverage==3.7.1
+coveralls==0.5
+pep8==1.5.7

--- a/tests/gen_cert_test.py
+++ b/tests/gen_cert_test.py
@@ -4,9 +4,10 @@ import os
 import shutil
 import tempfile
 import urllib2
+from mock import patch
 
 from nose.plugins.skip import SkipTest
-from nose.tools import assert_true
+from nose.tools import assert_true, assert_false
 
 import settings
 from gen_cert import CertificateGen
@@ -65,6 +66,25 @@ def test_cert_gen():
         # Remove files
         if os.path.exists(tmpdir):
             shutil.rmtree(tmpdir)
+
+
+@patch('gen_cert.TMP_GEN_DIR', new_callable=tempfile.mkdtemp)
+def test_creates_default_dir(gen_dir):
+    """Make sure the certificate generator creates the default directory if it doesn't exist."""
+    gen = None
+    try:
+        assert_true(os.path.exists(gen_dir))
+        shutil.rmtree(gen_dir)
+        assert_false(os.path.exists(gen_dir))
+        gen = CertificateGen(settings.CERT_DATA.keys()[0])
+        assert_true(os.path.exists(gen.dir_prefix))
+    finally:
+        if os.path.exists(gen_dir):
+            shutil.rmtree(gen_dir)
+        if gen:
+            # Avoid catastrophy
+            assert_true(gen.dir_prefix.startswith(gen_dir))
+            shutil.rmtree(gen.dir_prefix)
 
 
 def test_cert_names():


### PR DESCRIPTION
The certificate generation routine tries to make sure that the path for generating certificates exists if it is specified. However, the conditional logic neglects to do so if the default path is used.
