### PR TITLE
Only build travis push on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: python
 sudo: false
 python:
   - "2.7"
+branches:
+  only:
+    - master
+before_install:
+  - export BOTO_CONFIG=/dev/null
 install:
   - pip install --allow-all-external -r requirements.txt
   - pip install -r test_requirements.txt


### PR DESCRIPTION
I've been adding some automation for creating and testing openedx releases, which creates branches in a number of IDA's, and (if desired) deletes them at the end of the tests. For now, the job is in the beginning stages, and just creates a branch, and later deletes it.

The problem is, the branch gets deleted so quickly, that travis gets kicked off, but quickly fails when the branch can't be found. To make matters worse, since the branch doesn't include any new commits, travis gets run (and fails) on the same commit as the tip of the master branch, which overwrites whatever status it previously had to failing (example: link to failing travis build).

This change fixes that, by following a travis pattern we currently already use in other repos, like these: (configuration repo, devstack repo). This will limit builds to being triggered either by a pull request, or a push to master.

So when any non-master branch gets created or pushed, travis will not be triggered (unless there is an open pull request for that branch).

Also, Travis has been failing due to the following exception:
```
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/nose/loader.py", line 390, in loadTestsFromName
    addr.filename, addr.module)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/nose/importer.py", line 39, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/nose/importer.py", line 86, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/home/travis/build/edx/edx-certificates/tests/gen_cert_test.py", line 13, in <module>
    from gen_cert import CertificateGen
  File "/home/travis/build/edx/edx-certificates/gen_cert.py", line 34, in <module>
    import boto.s3
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/boto/__init__.py", line 934, in <module>
    boto.plugin.load_plugins(config)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/boto/plugin.py", line 89, in load_plugins
    _import_module(file)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/boto/plugin.py", line 72, in _import_module
    return imp.load_module(name, file, filename, data)
  File "/usr/lib/python2.7/dist-packages/google_compute_engine/boto/compute_auth.py", line 19, in <module>
    from google_compute_engine import logger
ImportError: No module named google_compute_engine
```

We've patched this in at least one other edx repo (https://github.com/edx/edx-analytics-pipeline/pull/424) with `export BOTO_CONFIG=/dev/null`.