### PR TITLE
Fix `CERT_DATA` encoding

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -145,5 +145,5 @@ if os.path.isfile(ENV_ROOT / "auth.json"):
 
 TEMPLATE_DIR = os.path.join(CERT_PRIVATE_DIR, TEMPLATE_DATA_SUBDIR)
 
-with open(os.path.join(CERT_PRIVATE_DIR, CERT_DATA_FILE)) as f:
+with open(os.path.join(CERT_PRIVATE_DIR, CERT_DATA_FILE), encoding='utf-8') as f:
     CERT_DATA = yaml.load(f.read())


### PR DESCRIPTION
After switching `edx-certificates` to Python 3.5 in  edx/configuration#5951, we discovered that the `CERT_DATA` fails to load from [the default data file](https://github.com/edx/edx-certificates/blob/master/cert-data.yml).

Related traceback:
```python
Traceback (most recent call last):
  File "/edx/app/certs/certificates/certificate_agent.py", line 8, in <module>
    import settings
  File "/edx/app/certs/certificates/settings.py", line 151, in <module>
    CERT_DATA = yaml.load(f.read())
  File "/edx/app/certs/venvs/certs/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 112: ordinal not in range(128)
```

### Testing instructions:
1. Ensure that the instance gets deployed. `/edx/bin/supervisorctl start certs` was breaking the deployment before this fix.

**Reviewers**
- [ ] @kelketek
- [ ] edX reviewer[s] TBD