### PR TITLE
[BB-3328] Pin `setuptools` in requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 python:
   - "2.7"
 install:
-  - pip install --allow-all-external -r requirements.txt
+  - pip install -r requirements.txt
   - pip install -r test_requirements.txt
 script:
   - pep8 --verbose

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ python-bidi==0.3.4
 PyYAML==3.11
 reportlab==3.1.44
 requests==2.3.0
+setuptools==44.1.1
 git+https://github.com/edx/opaque-keys.git@1254ed4d615a428591850656f39f26509b86d30a#egg=opaque-keys


### PR DESCRIPTION
Installing `python-bidi==0.3.4` instances fails for ginkgo while using the default version of setuptools (`45.0.0`).