### PR TITLE
[FAL-2232] feat: log added in get_length() on invalid code

### DIFF
--- a/openedx_certificates/queue_xqueue.py
+++ b/openedx_certificates/queue_xqueue.py
@@ -55,7 +55,8 @@ class XQueuePullManager:
                 self.url), params={'queue_name': self.queue_name})
             response = json.loads(request.text)
             if response['return_code'] != 0:
-                raise Exception("Invalid return code in reply")
+                raise Exception("Invalid return code in reply resp: {}".format(
+                    str(response)))
             length = int(response['content'])
         except (ValueError, Exception, ConnectionError, Timeout) as e:
             log.critical("Unable to get queue length: {0}".format(e))


### PR DESCRIPTION
## Description
In the logs of one of our edx instances we found the exception : `Invalid return code in reply`, what happens when calling `get_length()`. The problem is that this message does not provide much information of the error that occurs in the request. 
In this PR I added log to get more information about the error.