### PR TITLE
Removes created tmpdir when certificate template isn't found

### DIFF
--- a/gen_cert.py
+++ b/gen_cert.py
@@ -263,6 +263,7 @@ class CertificateGen(object):
             self.template_pdf = PdfFileReader(open(template_pdf_filename, "rb"))
         except IOError as e:
             log.critical("I/O error ({0}): {1} opening {2}".format(e.errno, e.strerror, template_pdf_filename))
+            os.rmdir(dir_prefix)
             raise
 
         self.cert_label_singular = cert_data.get('CERTS_ARE_CALLED', CERTS_ARE_CALLED)


### PR DESCRIPTION
## Description

This pull request includes a change that cleanup the tmpdir created during certificate creation if the process fails.
Previously these temporary directories would be left in `/tmp`

## Testing instructions

1. Setup a test course with certificates.
2. Force the certificate to fail (you can include an `assert False` [here](https://github.com/edx/edx-certificates/compare/master...open-craft:paulo/cleanup-tmp-on-raise#diff-d8fdb3339adf857211b170f9a1b886e37bf4878c004b24182ef2fdb2be5c22a7R261)
3. Get the certificate process to try to generate a certificate and fail.
4. Check `/tmp` on the server/devstack and see it has leftovers.
5. Install this branch.
6. Repeate 3 and 4, this time with no leftovers.