### PR TITLE
removed reference to edx as a non-profit from templates

### DIFF
--- a/template_data/v2/invalid.html
+++ b/template_data/v2/invalid.html
@@ -83,7 +83,7 @@
         <div class="supplemental__about">
           <h2 class="title">About edX</h2>
           <div class="copy">
-            <p>EdX offers interactive online classes and MOOCs from the world’s best universities, including MIT, Harvard, Berkeley, University of Texas, and many others.  EdX is a non-profit online initiative created by founding partners Harvard and MIT.</p>
+            <p>EdX offers interactive online classes and MOOCs from the world’s best universities, including MIT, Harvard, Berkeley, University of Texas, and many others.  EdX is an online initiative created by founding partners Harvard and MIT.</p>
           </div>
 
           <ul class="list list--actions">

--- a/template_data/v2/invalid.html
+++ b/template_data/v2/invalid.html
@@ -83,7 +83,7 @@
         <div class="supplemental__about">
           <h2 class="title">About edX</h2>
           <div class="copy">
-            <p>EdX offers interactive online classes and MOOCs from the world’s best universities, including MIT, Harvard, Berkeley, University of Texas, and many others.  EdX is an online initiative created by founding partners Harvard and MIT.</p>
+            <p>EdX offers interactive online classes and MOOCs from the world’s best universities, including MIT, Harvard, Berkeley, University of Texas, and many others. edX is a mission driven initiative created by founding partners Harvard and MIT.</p>
           </div>
 
           <ul class="list list--actions">

--- a/template_data/v2/valid.html
+++ b/template_data/v2/valid.html
@@ -103,7 +103,7 @@
         <div class="supplemental__about">
           <h2 class="title">About edX</h2>
           <div class="copy">
-            <p>EdX offers interactive online classes and MOOCs from the world’s best universities, including MIT, Harvard, Berkeley, University of Texas, and many others.  EdX is an online initiative created by founding partners Harvard and MIT.</p>
+            <p>EdX offers interactive online classes and MOOCs from the world’s best universities, including MIT, Harvard, Berkeley, University of Texas, and many others.  edX is an online initiative created by founding partners Harvard and MIT.</p>
           </div>
 
           <ul class="list list--actions">

--- a/template_data/v2/valid.html
+++ b/template_data/v2/valid.html
@@ -103,7 +103,7 @@
         <div class="supplemental__about">
           <h2 class="title">About edX</h2>
           <div class="copy">
-            <p>EdX offers interactive online classes and MOOCs from the world’s best universities, including MIT, Harvard, Berkeley, University of Texas, and many others.  edX is an online initiative created by founding partners Harvard and MIT.</p>
+            <p>EdX offers interactive online classes and MOOCs from the world’s best universities, including MIT, Harvard, Berkeley, University of Texas, and many others. edX is a mission driven initiative created by founding partners Harvard and MIT.</p>
           </div>
 
           <ul class="list list--actions">

--- a/template_data/v2/valid.html
+++ b/template_data/v2/valid.html
@@ -103,7 +103,7 @@
         <div class="supplemental__about">
           <h2 class="title">About edX</h2>
           <div class="copy">
-            <p>EdX offers interactive online classes and MOOCs from the world’s best universities, including MIT, Harvard, Berkeley, University of Texas, and many others.  EdX is a non-profit online initiative created by founding partners Harvard and MIT.</p>
+            <p>EdX offers interactive online classes and MOOCs from the world’s best universities, including MIT, Harvard, Berkeley, University of Texas, and many others.  EdX is an online initiative created by founding partners Harvard and MIT.</p>
           </div>
 
           <ul class="list list--actions">


### PR DESCRIPTION
Minor changes to 2 templates, removing reference to edx's status as a non-profit.